### PR TITLE
#18 – Frontend: App component unit test

### DIFF
--- a/apps/frontend/src/App.test.tsx
+++ b/apps/frontend/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { App } from './App';
+
+describe('App', () => {
+  it('renders the heading', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { name: 'Todo App' })).toBeDefined();
+  });
+});

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["vitest/globals"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Adds `apps/frontend/src/App.test.tsx` — renders `<App />` and asserts the `h1` heading is present
- Adds `"types": ["vitest/globals"]` to `apps/frontend/tsconfig.json` so `describe`/`it`/`expect` pass `tsc --noEmit`

## Test plan

- [x] `pnpm test` — 1 test passes
- [x] `pnpm typecheck` — no errors
- [x] `pnpm lint` — no errors

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)