### PR TITLE
feat(#73): register POST /todos route via todos router plugin

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,10 +1,12 @@
 import Fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import { todosRouter } from './routes/todos/router.js';
 
 export const buildApp = (): FastifyInstance => {
   const app = Fastify({ logger: true });
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
+  app.register(todosRouter);
   return app;
 };

--- a/apps/backend/src/routes/todos/create.test.ts
+++ b/apps/backend/src/routes/todos/create.test.ts
@@ -1,5 +1,4 @@
 import { buildApp } from '../../app.js';
-import { registerCreateTodoRoute } from './create.js';
 import { prisma } from '../../db.js';
 
 jest.mock('../../db.js', () => ({
@@ -14,7 +13,6 @@ describe('POST /todos', () => {
     jest.mocked(prisma.todo.create).mockResolvedValue(todo);
 
     const app = buildApp();
-    registerCreateTodoRoute(app);
     const response = await app.inject({ method: 'POST', url: '/todos', payload: { title: 'Buy milk' } });
 
     expect(response.statusCode).toBe(201);
@@ -23,7 +21,6 @@ describe('POST /todos', () => {
 
   it('returns 400 when title is missing', async () => {
     const app = buildApp();
-    registerCreateTodoRoute(app);
     const response = await app.inject({ method: 'POST', url: '/todos', payload: {} });
 
     expect(response.statusCode).toBe(400);

--- a/apps/backend/src/routes/todos/router.ts
+++ b/apps/backend/src/routes/todos/router.ts
@@ -1,0 +1,6 @@
+import type { FastifyInstance } from 'fastify';
+import { registerCreateTodoRoute } from './create.js';
+
+export const todosRouter = async (app: FastifyInstance): Promise<void> => {
+  registerCreateTodoRoute(app);
+};


### PR DESCRIPTION
## Summary
- Adds `apps/backend/src/routes/todos/router.ts` — Fastify plugin that registers `POST /todos` using `registerCreateTodoRoute`
- Updates `apps/backend/src/app.ts` — registers the todos router plugin via `app.register(todosRouter)`
- Updates `create.test.ts` — removes manual `registerCreateTodoRoute(app)` calls since the route is now registered through `buildApp()`

## Test plan
- [ ] `POST /todos` is reachable through the app (via `buildApp()`)
- [ ] Existing `create.test.ts` tests pass without manually registering the route
- [ ] Typecheck, lint, and unit tests all pass

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)