### PR TITLE
feat(#76): add GET /todos handler, unit tests, and register route

### DIFF
--- a/apps/backend/src/routes/todos/list.test.ts
+++ b/apps/backend/src/routes/todos/list.test.ts
@@ -1,0 +1,33 @@
+import { buildApp } from '../../app.js';
+import { prisma } from '../../db.js';
+
+jest.mock('../../db.js', () => ({
+  prisma: { todo: { findMany: jest.fn(), create: jest.fn() } },
+}));
+
+describe('GET /todos', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('returns 200 with array of todos', async () => {
+    const todos = [
+      { id: 1, title: 'Buy milk', completed: false, createdAt: new Date(), updatedAt: new Date() },
+    ];
+    jest.mocked(prisma.todo.findMany).mockResolvedValue(todos);
+
+    const app = buildApp();
+    const response = await app.inject({ method: 'GET', url: '/todos' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject([{ id: 1, title: 'Buy milk', completed: false }]);
+  });
+
+  it('returns 200 with empty array when no todos exist', async () => {
+    jest.mocked(prisma.todo.findMany).mockResolvedValue([]);
+
+    const app = buildApp();
+    const response = await app.inject({ method: 'GET', url: '/todos' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([]);
+  });
+});

--- a/apps/backend/src/routes/todos/list.ts
+++ b/apps/backend/src/routes/todos/list.ts
@@ -1,0 +1,9 @@
+import type { FastifyInstance } from 'fastify';
+import { prisma } from '../../db.js';
+
+export const registerListTodosRoute = (app: FastifyInstance): void => {
+  app.get('/todos', async (_request, reply) => {
+    const todos = await prisma.todo.findMany();
+    return reply.status(200).send(todos);
+  });
+};

--- a/apps/backend/src/routes/todos/router.ts
+++ b/apps/backend/src/routes/todos/router.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from 'fastify';
 import { registerCreateTodoRoute } from './create.js';
+import { registerListTodosRoute } from './list.js';
 
 export const todosRouter = async (app: FastifyInstance): Promise<void> => {
   registerCreateTodoRoute(app);
+  registerListTodosRoute(app);
 };


### PR DESCRIPTION
## Summary
- Adds `apps/backend/src/routes/todos/list.ts` — `GET /todos` handler returning all todos via `prisma.todo.findMany()`
- Adds `apps/backend/src/routes/todos/list.test.ts` — unit tests with mocked Prisma (returns list, returns empty array)
- Updates `apps/backend/src/routes/todos/router.ts` — registers `registerListTodosRoute` alongside the existing POST handler

## Test plan
- [ ] `GET /todos` returns an array of todos
- [ ] `GET /todos` returns empty array when none exist
- [ ] Typecheck, lint, and all 5 unit tests pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)